### PR TITLE
Update jekyll doc url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # thoughtram Blog
 
 
-We use Jekyll as static site generator. You can read its docs [here](jekyllrb.com/docs/).
+We use Jekyll as static site generator. You can read its docs [here](http://jekyllrb.com/docs/home/).


### PR DESCRIPTION
Updated jekyll doc url from 'jekyllrb.com/docs/' to 'http://jekyllrb.com/docs/home/'

'jekyllrb.com/docs/' - was leading to this 404 page: 'https://github.com/toddmotto/blog/blob/patch-1/jekyllrb.com/docs'
